### PR TITLE
Add missing `set` import.

### DIFF
--- a/homograph-detector.gemspec
+++ b/homograph-detector.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |spec|
   spec.name = 'homograph-detector'
-  spec.version = '0.1.0'
+  spec.version = '0.1.1'
   spec.authors = 'Kickstarter Engineering'
   spec.email = 'eng@kickstarter.com'
   spec.summary = %q{Ruby Gem used for homograph detection}

--- a/lib/homograph_detector.rb
+++ b/lib/homograph_detector.rb
@@ -3,6 +3,7 @@
 require 'addressable/uri'
 require 'unicode/confusable'
 require 'unicode/scripts'
+require 'set'
 
 class HomographDetector
   # Unicode Script names returned by the 'unicode-scripts' gem


### PR DESCRIPTION
We use `Set`s extensively through the gem, but don't ever explicitly
require it. This was presumably not caught in tests because one of our
test dependencies (or transitive dependencies) probably imports it.